### PR TITLE
Support authentication with simple API key (no oauth required)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,33 @@ Installation
 $ gem install cloudsight
 ```
 
+Install the `simple_oauth` gem to use with oauth options.
+
+```
+$ gem install simple_oauth
+```
+
 Configuration
 =============
 
 ```ruby
 require 'rubygems'
+require 'simple_oauth'
 require 'cloudsight'
 
 Cloudsight.oauth_options = {
   consumer_key: 'REPLACE WITH YOUR KEY',
   consumer_secret: 'REPLACE WITH YOUR SECRET'
 }
+```
+
+or, using a single API key:
+
+```ruby
+require 'rubygems'
+require 'cloudsight'
+
+Cloudsight.api_key = 'REPLACE WITH YOUR KEY'
 ```
 
 Usage

--- a/lib/cloudsight.rb
+++ b/lib/cloudsight.rb
@@ -34,11 +34,11 @@ module Cloudsight
 		end
 
 		def api_key
-			@@api_key
+			@@api_key if defined?(@@api_key)
 		end
 
 		def oauth_options
-			@@oauth_options
+			@@oauth_options if defined?(@@oauth_options)
 		end
 
 		def base_url=(val)
@@ -52,6 +52,7 @@ module Cloudsight
 
 	class Request
 		def self.send(options = {})
+			raise RuntimeError.new("Need to define either oauth_options or api_key") unless Cloudsight.api_key || Cloudsight.oauth_options
 			url = "#{Cloudsight::base_url}/image_requests"
 
 			params = {}


### PR DESCRIPTION
Also, document the requirement to install the `simple_oauth` gem, when authenticating with oauth.
