### PR TITLE
Move gem dependencies into gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'rake'
-gem 'json'
-gem 'rest-client'
-gem 'simple_oauth'
-
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,38 @@
+PATH
+  remote: .
+  specs:
+    cloudsight (0.0.2)
+      json
+      rest-client (~> 1.6)
+      simple_oauth
+
 GEM
   remote: https://rubygems.org/
   specs:
-    json (1.8.1)
-    mime-types (2.2)
+    domain_name (0.5.20170223)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
+    json (2.0.3)
+    mime-types (1.25.1)
+    netrc (0.11.0)
     rake (10.3.2)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
-    simple_oauth (0.2.0)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    simple_oauth (0.3.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  json
+  bundler (~> 1.6)
+  cloudsight!
   rake
-  rest-client
-  simple_oauth
+
+BUNDLED WITH
+   1.13.7

--- a/cloudsight.gemspec
+++ b/cloudsight.gemspec
@@ -12,20 +12,25 @@ Gem::Specification.new do |s|
   s.authors     = ['Brad Folkens']
   s.email       = 'brad@cloudsightapi.com'
   s.homepage    = 'http://github.com/cloudsight/cloudsight-ruby'
-	s.license			= 'MIT'
-	s.platform    = Gem::Platform::RUBY
+  s.license			= 'MIT'
+  s.platform    = Gem::Platform::RUBY
 
   s.files       = [
-		'lib/cloudsight.rb',
-		'Gemfile',
-		'Gemfile.lock',
-		'MIT-LICENSE',
-		'README.md',
-		'cloudsight.gemspec'
-	]
-	s.require_paths = [%q{lib}]
+    'lib/cloudsight.rb',
+    'Gemfile',
+    'Gemfile.lock',
+    'MIT-LICENSE',
+    'README.md',
+    'cloudsight.gemspec'
+  ]
+  s.require_paths = [%q{lib}]
 
-	s.required_ruby_version = Gem::Requirement.new('>= 1.9.1')
-	s.add_development_dependency 'bundler', '~> 1.6'
-	s.add_development_dependency 'rake'
+  s.required_ruby_version = Gem::Requirement.new('>= 1.9.1')
+
+  s.add_dependency 'json'
+  s.add_dependency 'rest-client', '~>1.6'
+  s.add_dependency 'simple_oauth'
+
+  s.add_development_dependency 'bundler', '~> 1.6'
+  s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Moved rest-client, json, simple_oauth dependencies from the Gemfile to the gemspec. This enables them to be treated as part of the dependency graph by bundler.