### PR TITLE
Handle JSON::ParserError when invalid JSON is returned

### DIFF
--- a/lib/cloudsight/request.rb
+++ b/lib/cloudsight/request.rb
@@ -12,6 +12,9 @@ module Cloudsight
         raise UnexpectedResponseException.new(response.body) unless data['token']
 
         data
+
+      rescue JSON::ParserError
+        raise UnexpectedResponseException.new(response.body)
       end
 
       def repost(token, options = {})
@@ -25,6 +28,9 @@ module Cloudsight
         raise UnexpectedResponseException.new(response.body) unless data['token']
 
         data
+
+      rescue JSON::ParserError
+        raise UnexpectedResponseException.new(response.body)
       end
 
       def construct_params(options)

--- a/lib/cloudsight/response.rb
+++ b/lib/cloudsight/response.rb
@@ -10,6 +10,9 @@ module Cloudsight
         raise UnexpectedResponseException.new(response.body) unless data['status']
 
         data
+
+      rescue JSON::ParserError
+        raise UnexpectedResponseException.new(response.body)
       end
 
       def retrieve(token, options = {})

--- a/spec/cloudsight/request_spec.rb
+++ b/spec/cloudsight/request_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Cloudsight::Request do
         response: fixture_file('image_request.json')
       )
 
-      response = described_class.send(params) 
+      response = described_class.send(params)
 
       expect(response["token"]).to  eq "sample_token"
       expect(response["url"]).to    eq "https://example.com/image.jpg"
@@ -77,6 +77,16 @@ RSpec.describe Cloudsight::Request do
         path: '/v1/images',
         body: { "locale" => "en", "remote_image_url" => "test_url" },
         response: fixture_file('unexpected_response.json')
+      )
+
+      expect { described_class.send(params) }.to raise_error Cloudsight::UnexpectedResponseException
+    end
+
+    it 'responds correctly to an invalid JSON response' do
+      stub_post(
+        path: '/v1/images',
+        body: { "locale" => "en", "remote_image_url" => "test_url" },
+        response: fixture_file('invalid_json.json')
       )
 
       expect { described_class.send(params) }.to raise_error Cloudsight::UnexpectedResponseException
@@ -115,6 +125,16 @@ RSpec.describe Cloudsight::Request do
         path: '/v1/images/sample_token/repost',
         body: { "locale" => "en", "remote_image_url" => "test_url" },
         response: fixture_file('unexpected_response.json')
+      )
+
+      expect { described_class.repost('sample_token', params) }.to raise_error Cloudsight::UnexpectedResponseException
+    end
+
+    it 'responds correctly to an invalid JSON response' do
+      stub_post(
+        path: '/v1/images/sample_token/repost',
+        body: { "locale" => "en", "remote_image_url" => "test_url" },
+        response: fixture_file('invalid_json.json')
       )
 
       expect { described_class.repost('sample_token', params) }.to raise_error Cloudsight::UnexpectedResponseException

--- a/spec/cloudsight/response_spec.rb
+++ b/spec/cloudsight/response_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe Cloudsight::Response do
 
       expect { described_class.get('sample_token') }.to raise_error Cloudsight::UnexpectedResponseException
     end
+
+    it 'responds correctly to an invalid JSON response' do
+      stub_get(
+        path: '/v1/images/sample_token',
+        response: fixture_file('invalid_json.json')
+      )
+
+      expect { described_class.get('sample_token') }.to raise_error Cloudsight::UnexpectedResponseException
+    end
   end
 
   describe '#retrieve' do
@@ -57,6 +66,12 @@ RSpec.describe Cloudsight::Response do
 
     it 'responds correctly to an unexpected response' do
       stub_polling(3, 'image_request.json', 'unexpected_response.json', '/v1/images/sample_token')
+
+      expect { described_class.retrieve('sample_token', poll_wait: 0.01) }.to raise_error Cloudsight::UnexpectedResponseException
+    end
+
+    it 'responds correctly to an invalid JSON response' do
+      stub_polling(3, 'image_request.json', 'invalid_json.json', '/v1/images/sample_token')
 
       expect { described_class.retrieve('sample_token', poll_wait: 0.01) }.to raise_error Cloudsight::UnexpectedResponseException
     end

--- a/spec/fixtures/invalid_json.json
+++ b/spec/fixtures/invalid_json.json
@@ -1,0 +1,9 @@
+<html><head>
+<meta http-equiv="content-type" content="text/html;charset=utf-8">
+<title>502 Server Error</title>
+</head>
+<body text=#000000 bgcolor=#ffffff>
+<h1>Error: Server Error</h1>
+<h2>The server encountered a temporary error and could not complete your request.<p>Please try again in 30 seconds.</h2>
+<h2></h2>
+</body></html>


### PR DESCRIPTION
Sometimes cloudsight returns a server error HTML page instead of JSON, which causes `JSON.parse` to raise a `JSON::ParserError`. This change catches that and returns `UnexpectedResponseException` instead so that clients can catch it.